### PR TITLE
set correct error code

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"sync"
-
+        "github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -57,7 +57,7 @@ func (m *MockS3) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error
 
 	buf, ok := bucket.objects[*input.Key]
 	if !ok {
-		return nil, fmt.Errorf("not found")
+		return nil, awserr.New(s3.ErrCodeNoSuchKey, "not found", nil)
 	}
 
 	return &s3.GetObjectOutput{


### PR DESCRIPTION
Checking the AWS SDK implementation for s3, it returns s3.ErrCodeNoSuchKey error type when the key doesn't exist. This is relevant (at least at my case) for testing purposes.